### PR TITLE
Allow assignment of picker hitter/pitcher disposition

### DIFF
--- a/lib/drafter.rb
+++ b/lib/drafter.rb
@@ -5,12 +5,17 @@ require "drafter/choice"
 require "drafter/potential_slots_for_picker"
 
 class Drafter
-  def initialize(candidates:, pickers:, slot_counts:, debug: false)
+  def initialize(candidates:, pickers:, dispositions: [1.0], slot_counts:, debug: false)
     @candidates = candidates.sort_by { |candidate| candidate[:value] }.reverse
     @slot_counts = slot_counts
     @debug = debug
 
-    @results = Array.new(pickers) { Drafter::Picker.new }
+    @results = []
+    until results.count == pickers do
+      results << Drafter::Picker.new(
+        disposition: dispositions[results.count % dispositions.count],
+      )
+    end
   end
 
   def draft
@@ -45,7 +50,11 @@ class Drafter
 
   def make_pick_for_picker(picker)
     time = Time.now
-    top_candidate = Choice.new(candidates: candidates, slot_counts: slot_counts, picker: picker).top_candidate
+    top_candidate = Choice.new(
+      candidates: candidates,
+      slot_counts: slot_counts,
+      picker: picker,
+    ).top_candidate
 
     if top_candidate
       debug_puts "#{top_candidate[:name]}, took #{Time.now - time}s"

--- a/lib/drafter/choice.rb
+++ b/lib/drafter/choice.rb
@@ -11,7 +11,7 @@ class Drafter::Choice
       best_available_player
     else
       puts "Potential slots: #{potential_slots}:"
-      candidate = candidates.detect do |candidate|
+      candidate = weighted_candidates.detect do |candidate|
         candidate[:slots].any? do |slot|
           potential_slots.include?(slot)
         end
@@ -36,7 +36,7 @@ class Drafter::Choice
   end
 
   def best_available_player
-    @_best_available_player ||= candidates.first
+    @_best_available_player ||= weighted_candidates.first
   end
 
   def filled_slots
@@ -52,5 +52,15 @@ class Drafter::Choice
       picker: picker,
       slot_counts: slot_counts
     )
+  end
+
+  def weighted_candidates
+    @_weighted_candidates ||= candidates.sort_by do |candidate|
+      if candidate[:slots].include?(:u)
+        candidate[:value] * picker.disposition
+      else
+        candidate[:value]
+      end
+    end.reverse
   end
 end

--- a/lib/drafter/picker.rb
+++ b/lib/drafter/picker.rb
@@ -1,9 +1,10 @@
 class Drafter::Picker
-  attr_reader :cached_assignments, :picks
+  attr_reader :cached_assignments, :disposition, :picks
 
-  def initialize
+  def initialize(disposition: 1.0)
     @picks = []
     @cached_assignments = []
+    @disposition = disposition
   end
 
   def cache_assignments(assignments)

--- a/spec/drafter/choice_spec.rb
+++ b/spec/drafter/choice_spec.rb
@@ -18,6 +18,22 @@ RSpec.describe Drafter::Choice do
 
         expect(choice.top_candidate[:id]).to eq(best[:id])
       end
+
+      it "respects the hitter-bias disposition" do
+        pitcher = { id: 1, value: 100, slots: [:sp] }
+        best_hitter = { id: 2, value: 90, slots: [:u] }
+        caddy = { id: 3, value: 80, slots: [:u] }
+        candidates = [pitcher, best_hitter, caddy]
+        picker = Drafter::Picker.new(disposition: 1.2)
+
+        choice = Drafter::Choice.new(
+          candidates: candidates,
+          picker: picker,
+          slot_counts: { sp: 1, u: 1 },
+        )
+
+        expect(choice.top_candidate[:id]).to eq(best_hitter[:id])
+      end
     end
 
     context "with a filled position" do

--- a/spec/drafter_spec.rb
+++ b/spec/drafter_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe Drafter do
     expect(results.count).to eq(3)
   end
 
+  it "assigns disposiitons evenly" do
+    candidates = []
+
+    drafter = Drafter.new(
+      candidates: candidates,
+      pickers: 5,
+      dispositions: [1.0, 1.1],
+      slot_counts: { u: 10 },
+    )
+
+    results = drafter.draft.map(&:disposition)
+    expect(results).to match_array([1.0, 1.0, 1.0, 1.1, 1.1])
+  end
+
   it "distributes candidates among the pickers efficiently" do
     candidates = [
       { id: "1st", value: 1000, slots: [:u] },


### PR DESCRIPTION
The currently generated simulated teams are as a whole league picking
the correct players, but every team making their choice with the same
ranking logic is resulting in counting stats for offense having standard
deviations that average about 20% lower than the standard deviations we
observed in our league in actual play (the means are within 5% in every
stat).

This change allows the assignment of dispositions to a picker. If a
picker has a disposition of 1.0, they pick the top player that fits
their roster by the consensus value. If the disposition is higher than
1.0, the team will "overvalue" hitters by re-sorting the candidates and
giving hitters a bump. If the disposition is below one, hitters get a
penalty.